### PR TITLE
Improve CMS links handling to preserve the SPA feeling

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,6 +4,7 @@ module.exports = {
         'gatsby-plugin-sass',
         'gatsby-plugin-use-dark-mode',
         'gatsby-transformer-yaml',
+        'gatsby-plugin-catch-links',
         {
             resolve: 'gatsby-plugin-google-analytics',
             options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12385,6 +12385,25 @@
         }
       }
     },
+    "gatsby-plugin-catch-links": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.3.1.tgz",
+      "integrity": "sha512-0hqe9mmJGPF+mh2Rrat1RhBBfm/rNi4nCEnsNSQ/j7h2w5btOny80B7He9JIqLTspcQhXuo709nGdOUqx+Qmyw==",
+      "requires": {
+        "@babel/runtime": "^7.9.6",
+        "escape-string-regexp": "^1.0.5"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "gatsby-plugin-google-analytics": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "fslightbox-react": "^1.4.9",
     "gatsby": "^2.21.9",
     "gatsby-image": "^2.4.0",
+    "gatsby-plugin-catch-links": "^2.3.1",
     "gatsby-plugin-google-analytics": "^2.3.0",
     "gatsby-plugin-manifest": "^2.4.1",
     "gatsby-plugin-netlify": "^2.3.0",


### PR DESCRIPTION
Install and configure [gatsby-plugin-catch-links](https://www.gatsbyjs.org/packages/gatsby-plugin-catch-links/). This plugin intercepts all local links that have not been created in React using gatsby-link, and replaces their behavior with that of the gatsby-link navigate. This avoids the browser having to refresh the whole page when navigating between local pages, preserving the Single Page Application (SPA) feel.